### PR TITLE
app-arch/7zip: add ~arm64 keyword

### DIFF
--- a/app-arch/7zip/7zip-23.01.ebuild
+++ b/app-arch/7zip/7zip-23.01.ebuild
@@ -17,7 +17,7 @@ S="${WORKDIR}"
 
 LICENSE="LGPL-2 BSD rar? ( unRAR )"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~arm64"
 IUSE="uasm jwasm rar"
 REQUIRED_USE="?? ( uasm jwasm )"
 


### PR DESCRIPTION
Adds the `~arm64` keyword to app-arch/7zip because I've been able to use it in a few different use-cases successfully now.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
